### PR TITLE
fixed covariates bug

### DIFF
--- a/permutation_testing.py
+++ b/permutation_testing.py
@@ -471,7 +471,7 @@ if __name__ == '__main__':
             y, 
             kinship_eigenvectors, 
             kinship_eigenvalues, 
-            covariates=None, 
+            covariates=covariates, 
             pylmm_resolution=100, 
             cutoff=args.cutoff)
 


### PR DESCRIPTION
I found a small error in the permutation_testing.py script that causes covariates to be excluded in all cases. Seems to work now. I have not contributed to someone elses github repo before, so hopefully I am doing it correctly. In case this does not work, I simply changed line 474 from `covariates=None` to `covariates=covariates`